### PR TITLE
[Styling] - Improve Feed screen display

### DIFF
--- a/src/ui/Detail/Detail.tsx
+++ b/src/ui/Detail/Detail.tsx
@@ -11,12 +11,8 @@ type Props = {
 }
 
 export const Detail = ({ title, description, image, onPress }: Props) => (
-  <Box vertical="spaceAround" testID="detailScreen">
-    <Image
-      style={{ height: 100, width: 100, alignSelf: 'center' }}
-      source={{ uri: image }}
-      testID="articleImage"
-    />
+  <Box horizontal="center" vertical="spaceAround" testID="detailScreen">
+    <Image style={{ height: 100, width: 100 }} source={{ uri: image }} testID="articleImage" />
     <Text bold="strong" size="big" center>
       {title}
     </Text>

--- a/src/ui/Feed/_components/molecules/ArticleHeader.tsx
+++ b/src/ui/Feed/_components/molecules/ArticleHeader.tsx
@@ -8,7 +8,9 @@ type Props = {
 
 export const ArticleHeader = ({ title, date }: Props) => (
   <Row horizontal="spaceBetween">
-    <Text bold="strong">{title}</Text>
-    <Text bold="strong">{date.toLocaleDateString()}</Text>
+    <Text bold="strong" shrink>
+      {title}
+    </Text>
+    <Text bold="strong">{date.getDate() + '/' + date.getMonth() + '/' + date.getFullYear()}</Text>
   </Row>
 )

--- a/src/ui/Feed/_components/molecules/ArticleHeader.tsx
+++ b/src/ui/Feed/_components/molecules/ArticleHeader.tsx
@@ -7,7 +7,7 @@ type Props = {
 }
 
 export const ArticleHeader = ({ title, date }: Props) => (
-  <Row vertical="spaceBetween">
+  <Row horizontal="spaceBetween">
     <Text bold="strong">{title}</Text>
     <Text bold="strong">{date.toLocaleDateString()}</Text>
   </Row>

--- a/src/ui/_components/_objects/Box.tsx
+++ b/src/ui/_components/_objects/Box.tsx
@@ -1,16 +1,19 @@
 import { ReactNode } from 'react'
 import { View } from 'react-native'
 
-import { PositionType, toContent } from '../../_styles/Position'
+import { JustifyKeys, toJustify, AlignKeys, toAlign } from '../../_styles/Position'
 
 type Props = {
   children: ReactNode
-  vertical?: PositionType
+  horizontal?: AlignKeys
+  vertical?: JustifyKeys
   testID?: string
 }
 
-export const Box = ({ children, vertical = 'start', testID }: Props) => (
-  <View style={[{ flex: 1 }, { justifyContent: toContent(vertical) }]} testID={testID}>
+export const Box = ({ children, horizontal = 'start', vertical = 'start', testID }: Props) => (
+  <View
+    style={{ flex: 1, justifyContent: toJustify(vertical), alignItems: toAlign(horizontal) }}
+    testID={testID}>
     {children}
   </View>
 )

--- a/src/ui/_components/_objects/Row.tsx
+++ b/src/ui/_components/_objects/Row.tsx
@@ -10,6 +10,13 @@ type Props = {
 
 export const Row = ({ children, horizontal = 'start' }: Props) => {
   return (
-    <View style={{ flexDirection: 'row', justifyContent: toJustify(horizontal) }}>{children}</View>
+    <View
+      style={{
+        flexDirection: 'row',
+        justifyContent: toJustify(horizontal),
+        width: '100%',
+      }}>
+      {children}
+    </View>
   )
 }

--- a/src/ui/_components/_objects/Row.tsx
+++ b/src/ui/_components/_objects/Row.tsx
@@ -1,15 +1,15 @@
 import { ReactNode } from 'react'
 import { View } from 'react-native'
 
-import { PositionType, toContent } from '../../_styles/Position'
+import { JustifyKeys, toJustify } from '../../_styles/Position'
 
 type Props = {
   children: ReactNode
-  vertical?: PositionType
+  horizontal?: JustifyKeys
 }
 
-export const Row = ({ children, vertical = 'start' }: Props) => {
+export const Row = ({ children, horizontal = 'start' }: Props) => {
   return (
-    <View style={{ flexDirection: 'row', justifyContent: toContent(vertical) }}>{children}</View>
+    <View style={{ flexDirection: 'row', justifyContent: toJustify(horizontal) }}>{children}</View>
   )
 }

--- a/src/ui/_components/atoms/Text.tsx
+++ b/src/ui/_components/atoms/Text.tsx
@@ -6,15 +6,23 @@ type Props = {
   size?: FontSizeType
   bold?: FontWeightType
   center?: boolean
+  shrink?: boolean
 } & TextProps
 
-export const Text = ({ size = 'small', bold = 'light', center = false, ...textProps }: Props) => {
+export const Text = ({
+  size = 'small',
+  bold = 'light',
+  center = false,
+  shrink = false,
+  ...textProps
+}: Props) => {
   return (
     <BaseText
       style={{
         fontSize: toSize(size),
         fontWeight: toWeight(bold),
         textAlign: center ? 'center' : 'left',
+        flexShrink: shrink ? 1 : 0,
       }}
       {...textProps}
     />

--- a/src/ui/_styles/Position.ts
+++ b/src/ui/_styles/Position.ts
@@ -1,11 +1,18 @@
-export enum Position {
+export enum Justify {
   start = 'flex-start',
-  center = 'center',
-  end = 'flex-end',
   spaceAround = 'space-around',
   spaceBetween = 'space-between',
 }
 
-export type PositionType = keyof typeof Position
+export type JustifyKeys = keyof typeof Justify
 
-export const toContent = (type: PositionType) => Position[type]
+export const toJustify = (type: JustifyKeys) => Justify[type]
+
+export enum Align {
+  start = 'flex-start',
+  center = 'center',
+}
+
+export type AlignKeys = keyof typeof Align
+
+export const toAlign = (type: AlignKeys) => Align[type]


### PR DESCRIPTION
[[ISSUE - 24]](https://github.com/David-Rodriguez-Garcia/portfolioChallenge/issues/24)

##What:
- Fixed display of the articles date on the Feed screen.
- Fixed Row object prop typo.
- Refactored styling of the Detail screen and of the Box and Row objects.
- Improved the typing for the justifyContent styling prop.
- Created the typing for the alignContent styling prop.

##Screenshots:

Before and after
<img src="https://user-images.githubusercontent.com/71403641/221447238-b27a533d-0ab8-46a5-9657-662222ab5881.jpg" alt="Screenshot_20230227_010214" width="45%">------------<img src="https://user-images.githubusercontent.com/71403641/221447242-04a4f919-4b07-4b82-8ecf-68c59207f831.jpg" alt="Screenshot_20230227_010122" width="45%">
